### PR TITLE
Changes explain() to utilize new storedResponse field of the Action class

### DIFF
--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
@@ -1,6 +1,7 @@
 package gov.nist.csd.pm.admintool.actions;
 
 import gov.nist.csd.pm.admintool.app.MainView;
+import gov.nist.csd.pm.admintool.services.coordinatorResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +20,7 @@ public abstract class Action {
         return params;
     }
 
-    public String explanation;
+    public coordinatorResponse storedResponse;
 
     public Map<String, Type> getParamNamesAndTypes() {
         HashMap<String, Type> ret = new HashMap<>();
@@ -63,6 +64,8 @@ public abstract class Action {
     }
 
     public abstract boolean run();
+
+    public abstract String explain();
 
     public abstract String toString();
 

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
@@ -1,7 +1,7 @@
 package gov.nist.csd.pm.admintool.actions;
 
 import gov.nist.csd.pm.admintool.app.MainView;
-import gov.nist.csd.pm.admintool.services.coordinatorResponse;
+import gov.nist.csd.pm.admintool.services.CoordinatorScenarioResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +20,7 @@ public abstract class Action {
         return params;
     }
 
-    public coordinatorResponse storedResponse;
+    public CoordinatorScenarioResponse storedResponse;
 
     public Map<String, Type> getParamNamesAndTypes() {
         HashMap<String, Type> ret = new HashMap<>();

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
@@ -19,6 +19,8 @@ public abstract class Action {
         return params;
     }
 
+    public String explanation;
+
     public Map<String, Type> getParamNamesAndTypes() {
         HashMap<String, Type> ret = new HashMap<>();
         for (String key: params.keySet()) {
@@ -61,8 +63,6 @@ public abstract class Action {
     }
 
     public abstract boolean run();
-
-    public abstract String explain();
 
     public abstract String toString();
 

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/Action.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Action {
-    public static String coordinatorURL = "http://localhost:8080";
+    public static String coordinatorURL = "http://localhost:8081";
 
     protected Map<String, Element> params = new HashMap<>();
     protected String name;

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
@@ -30,17 +30,26 @@ public class Ping extends Action {
         params.put("type", "ping");
         params.put("body", subParams);
 
-        coordinatorResponse response = RestService
+        this.storedResponse = RestService
                 .sendRequest(Action.coordinatorURL.concat("/scenario"), HttpMethod.POST, params);
-        Boolean success = response.success;
+
+        return this.storedResponse.success;
+    }
+
+    @Override
+    public String explain() {
+        String address = ((String)getParams().get("Address").getValue());
+        Integer count = ((Integer)getParams().get("Count").getValue());
+        Boolean success = this.storedResponse.success;
+        String explanation;
 
         if (success) {
-            this.explanation = "Ping test to " + address + " passed " + count + " times.";
+            explanation = "Ping test to " + address + " passed " + count + " times.";
         } else {
-            this.explanation = "Ping test to " + address + " failed:\n" + response.summary;
+            explanation = "Ping test to " + address + " failed:\n" + this.storedResponse.summary;
         }
 
-        return success;
+        return explanation;
     }
 
     @Override

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
@@ -2,7 +2,7 @@ package gov.nist.csd.pm.admintool.actions.scenarios;
 
 import gov.nist.csd.pm.admintool.actions.Action;
 import gov.nist.csd.pm.admintool.services.RestService;
-import gov.nist.csd.pm.admintool.services.coordinatorResponse;
+import gov.nist.csd.pm.admintool.services.CoordinatorScenarioResponse;
 import org.springframework.http.HttpMethod;
 
 import java.util.HashMap;
@@ -30,7 +30,7 @@ public class Ping extends Action {
         params.put("type", "ping");
         params.put("body", subParams);
 
-        coordinatorResponse response = RestService
+        CoordinatorScenarioResponse response = RestService
                 .sendRequest(Action.coordinatorURL.concat("/scenario"), HttpMethod.POST, params);
         Boolean success = response.success;
 

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
@@ -2,6 +2,7 @@ package gov.nist.csd.pm.admintool.actions.scenarios;
 
 import gov.nist.csd.pm.admintool.actions.Action;
 import gov.nist.csd.pm.admintool.services.RestService;
+import gov.nist.csd.pm.admintool.services.coordinatorResponse;
 import org.springframework.http.HttpMethod;
 
 import java.util.HashMap;
@@ -29,15 +30,17 @@ public class Ping extends Action {
         params.put("type", "ping");
         params.put("body", subParams);
 
+        coordinatorResponse response = RestService
+                .sendRequest(Action.coordinatorURL.concat("/scenario"), HttpMethod.POST, params);
+        Boolean success = response.success;
+
+        if (success) {
+            this.explanation = "Ping test to " + address + " passed " + count + " times.";
+        } else {
+            this.explanation = "Ping test to " + address + " failed:\n" + response.summary;
+        }
+
         return (RestService.sendRequest(Action.coordinatorURL.concat("/scenario"), HttpMethod.POST, params).success);
-    }
-
-    @Override
-    public String explain() {
-        String address = ((String)getParams().get("Address").getValue());
-        int count = ((int)getParams().get("Count").getValue());
-
-        return "Something";
     }
 
     @Override

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
@@ -2,7 +2,6 @@ package gov.nist.csd.pm.admintool.actions.scenarios;
 
 import gov.nist.csd.pm.admintool.actions.Action;
 import gov.nist.csd.pm.admintool.services.RestService;
-import gov.nist.csd.pm.admintool.services.CoordinatorScenarioResponse;
 import org.springframework.http.HttpMethod;
 
 import java.util.HashMap;

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/actions/scenarios/Ping.java
@@ -40,7 +40,7 @@ public class Ping extends Action {
             this.explanation = "Ping test to " + address + " failed:\n" + response.summary;
         }
 
-        return (RestService.sendRequest(Action.coordinatorURL.concat("/scenario"), HttpMethod.POST, params).success);
+        return success;
     }
 
     @Override

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
@@ -9,6 +9,9 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import gov.nist.csd.pm.admintool.actions.Action;
+import gov.nist.csd.pm.admintool.services.RestService;
+import gov.nist.csd.pm.admintool.services.coordinatorResponse;
+import org.springframework.http.HttpMethod;
 
 
 @Tag("settings")
@@ -51,8 +54,16 @@ public class Settings extends VerticalLayout {
             if (e.isOpened()) {
                 if (Action.coordinatorURL == null)
                     URLInput.setValue("");
-                else
+                else {
                     URLInput.setValue(Action.coordinatorURL);
+                    coordinatorResponse resp = RestService
+                            .sendRequest(Action.coordinatorURL.concat("/status"), HttpMethod.GET, null);
+
+                    if (resp != null && resp.status != null && resp.status.equals("ok"))
+                        coordinatorURL.getElement().getStyle().set("background", "#BEFFB5");
+                    else
+                        coordinatorURL.getElement().getStyle().set("background", "#FFBFB5");
+                }
             }
         });
         add(coordinatorURL);

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
@@ -9,9 +9,6 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import gov.nist.csd.pm.admintool.actions.Action;
-import gov.nist.csd.pm.admintool.services.RestService;
-import gov.nist.csd.pm.admintool.services.coordinatorResponse;
-import org.springframework.http.HttpMethod;
 
 
 @Tag("settings")
@@ -56,13 +53,6 @@ public class Settings extends VerticalLayout {
                     URLInput.setValue("");
                 else {
                     URLInput.setValue(Action.coordinatorURL);
-                    coordinatorResponse resp = RestService
-                            .sendRequest(Action.coordinatorURL.concat("/status"), HttpMethod.GET, null);
-
-                    if (resp != null && resp.status != null && resp.status.equals("ok"))
-                        coordinatorURL.getElement().getStyle().set("background", "#BEFFB5");
-                    else
-                        coordinatorURL.getElement().getStyle().set("background", "#FFBFB5");
                 }
             }
         });

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
@@ -5,10 +5,13 @@ import com.vaadin.flow.component.details.Details;
 import com.vaadin.flow.component.details.DetailsVariant;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import gov.nist.csd.pm.admintool.actions.Action;
+import gov.nist.csd.pm.admintool.services.RestService;
 
 
 @Tag("settings")
@@ -32,18 +35,37 @@ public class Settings extends VerticalLayout {
         setPadding(true);
 
 
-        // Unit Tester
+        Icon checkIcon = new Icon(VaadinIcon.CHECK);
+        checkIcon.setColor("green");
+        Icon closeIcon = new Icon(VaadinIcon.CLOSE);
+        closeIcon.setColor("red");
+        Icon loadingIcon = new Icon(VaadinIcon.COG);
+
         TextField URLInput = new TextField();
+        HorizontalLayout textAndIcon = new HorizontalLayout(URLInput, loadingIcon);
+        textAndIcon.setVerticalComponentAlignment(Alignment.CENTER);
+
+        // Unit Tester
         URLInput.addValueChangeListener((event) -> {
             if (event.getValue() == null || event.getValue().equals(""))
                 Action.coordinatorURL = null;
-            else
+            else {
                 Action.coordinatorURL = event.getValue();
+                if (RestService.checkCoordinatorStatus(Action.coordinatorURL + "/status")) {
+                    textAndIcon.removeAll();
+                    textAndIcon.add(URLInput, checkIcon);
+                }
+                else {
+                    textAndIcon.removeAll();
+                    textAndIcon.add(URLInput, closeIcon);
+                }
+            }
         });
         URLInput.setWidth("100%");
 
+
         coordinatorURL = new Details("Coordinator URL", null);
-        coordinatorURL.setContent(URLInput);
+        coordinatorURL.setContent(textAndIcon);
         coordinatorURL.getElement().getStyle()
                 .set("background", "#DADADA"); //#A0FFA0
         coordinatorURL.addThemeVariants(DetailsVariant.FILLED);
@@ -53,6 +75,15 @@ public class Settings extends VerticalLayout {
                     URLInput.setValue("");
                 else {
                     URLInput.setValue(Action.coordinatorURL);
+                    if (RestService.checkCoordinatorStatus(Action.coordinatorURL + "/status")) {
+                        textAndIcon.removeAll();
+                        textAndIcon.add(URLInput, checkIcon);
+                    }
+                    else {
+                        textAndIcon.removeAll();
+                        textAndIcon.add(URLInput, closeIcon);
+                    }
+
                 }
             }
         });

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/Settings.java
@@ -10,6 +10,7 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import gov.nist.csd.pm.admintool.actions.Action;
 import gov.nist.csd.pm.admintool.services.RestService;
 
@@ -17,7 +18,6 @@ import gov.nist.csd.pm.admintool.services.RestService;
 @Tag("settings")
 public class Settings extends VerticalLayout {
     private HorizontalLayout layout;
-    private Details coordinatorURL;
 
     public Settings() {
         layout = new HorizontalLayout();
@@ -34,18 +34,21 @@ public class Settings extends VerticalLayout {
         setSizeFull();
         setPadding(true);
 
+        // Creating URL Text Field
+        TextField URLInput = new TextField();
 
+        // Creating Each Icon
+        Icon loadingIcon = new Icon(VaadinIcon.COG);
         Icon checkIcon = new Icon(VaadinIcon.CHECK);
         checkIcon.setColor("green");
         Icon closeIcon = new Icon(VaadinIcon.CLOSE);
         closeIcon.setColor("red");
-        Icon loadingIcon = new Icon(VaadinIcon.COG);
 
-        TextField URLInput = new TextField();
+        // Creating and Configuring Text and Icon Horizontal Layout
         HorizontalLayout textAndIcon = new HorizontalLayout(URLInput, loadingIcon);
-        textAndIcon.setVerticalComponentAlignment(Alignment.CENTER);
+        textAndIcon.setAlignItems(Alignment.CENTER);
 
-        // Unit Tester
+        // Configuring URL Text Field
         URLInput.addValueChangeListener((event) -> {
             if (event.getValue() == null || event.getValue().equals(""))
                 Action.coordinatorURL = null;
@@ -63,8 +66,8 @@ public class Settings extends VerticalLayout {
         });
         URLInput.setWidth("100%");
 
-
-        coordinatorURL = new Details("Coordinator URL", null);
+        // Creating and Configuring Details Dropdown
+        Details coordinatorURL = new Details("Coordinator URL", null);
         coordinatorURL.setContent(textAndIcon);
         coordinatorURL.getElement().getStyle()
                 .set("background", "#DADADA"); //#A0FFA0
@@ -83,10 +86,11 @@ public class Settings extends VerticalLayout {
                         textAndIcon.removeAll();
                         textAndIcon.add(URLInput, closeIcon);
                     }
-
                 }
             }
         });
+        coordinatorURL.setOpened(true);
+
         add(coordinatorURL);
     }
 }

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
@@ -1,5 +1,6 @@
 package gov.nist.csd.pm.admintool.app;
 
+import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.accordion.Accordion;
 import com.vaadin.flow.component.accordion.AccordionPanel;
 import com.vaadin.flow.component.button.Button;
@@ -10,12 +11,10 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.IntegerField;
-import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextField;
 import gov.nist.csd.pm.admintool.actions.Action;
 import gov.nist.csd.pm.admintool.actions.SingletonActiveActions;
 import gov.nist.csd.pm.admintool.actions.scenarios.Ping;
-import gov.nist.csd.pm.admintool.app.MainView;
 import java.util.Map;
 
 public class UnitTester extends VerticalLayout {
@@ -55,8 +54,12 @@ public class UnitTester extends VerticalLayout {
 
         Button test = new Button("+", event -> {
             if (chosenTest != null) {
-                actions.add(chosenTest);
-                refreshComponent();
+                if (!filledParams()) {
+                    MainView.notify("Parameters are not filled.", MainView.NotificationType.ERROR);
+                } else {
+                    actions.add(chosenTest);
+                    refreshComponent();
+                }
             } else {
                 MainView.notify("No Test", MainView.NotificationType.DEFAULT);
             }
@@ -90,7 +93,7 @@ public class UnitTester extends VerticalLayout {
                                         chosenTest.setParamValue(paramName, textEvent.getValue());
                                     }
                                 });
-//                                textField.setValue("");
+                                //textField.setValue("");
                                 params.add(textField);
                                 break;
                             case INT:
@@ -103,7 +106,7 @@ public class UnitTester extends VerticalLayout {
                                         chosenTest.setParamValue(paramName, integerEvent.getValue());
                                     }
                                 });
-//                                integerField.setValue();
+                                //integerField.setValue();
                                 params.add(integerField);
                                 break;
                         }
@@ -116,6 +119,17 @@ public class UnitTester extends VerticalLayout {
         form.add(params);
 
         add(form);
+    }
+
+    private boolean filledParams() {
+        boolean paramsFilled = true;
+        Object[] parameterInputs = params.getChildren().toArray();
+        for (Object c: parameterInputs) {
+            if (c instanceof AbstractField) {
+                paramsFilled &= !((AbstractField<?, ?>) c).isEmpty();
+            }
+        }
+        return paramsFilled;
     }
 
     private void addListOfTests() {

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
@@ -139,7 +139,7 @@ public class UnitTester extends VerticalLayout {
             } else { // failed
                 regularPannel.getElement().getStyle().set("background", "#FFBFB5"); // failed
             }
-            String audit = action.explanation;
+            String audit = action.explain();
             auditLayout.setSizeFull();
             auditLayout.getStyle()
                     .set("padding-bottom", "0px");

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/app/UnitTester.java
@@ -132,8 +132,14 @@ public class UnitTester extends VerticalLayout {
             results.remove(c);
         });
         for (Action action: actions) {
-            String audit = action.explain();
             VerticalLayout auditLayout = new VerticalLayout();
+            AccordionPanel regularPannel = results.add(action.toString(), auditLayout);
+            if (action.run()) { // passed
+                regularPannel.getElement().getStyle().set("background", "#BEFFB5"); // passed
+            } else { // failed
+                regularPannel.getElement().getStyle().set("background", "#FFBFB5"); // failed
+            }
+            String audit = action.explanation;
             auditLayout.setSizeFull();
             auditLayout.getStyle()
                     .set("padding-bottom", "0px");
@@ -154,12 +160,6 @@ public class UnitTester extends VerticalLayout {
                 }
             } else {
                 auditLayout.add(new Span(audit));
-            }
-            AccordionPanel regularPannel = results.add(action.toString(), auditLayout);
-            if (action.run()) { // passed
-                regularPannel.getElement().getStyle().set("background", "#BEFFB5"); // passed
-            } else { // failed
-                regularPannel.getElement().getStyle().set("background", "#FFBFB5"); // failed
             }
             regularPannel.addThemeVariants(DetailsVariant.FILLED, DetailsVariant.REVERSE);
             results.close();

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorScenarioResponse.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorScenarioResponse.java
@@ -3,4 +3,11 @@ package gov.nist.csd.pm.admintool.services;
 public class CoordinatorScenarioResponse {
     public Boolean success;
     public String summary;
+
+    public CoordinatorScenarioResponse() {}
+
+    public CoordinatorScenarioResponse (Boolean success, String summary) {
+        this.success = success;
+        this.summary = summary;
+    }
 }

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorScenarioResponse.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorScenarioResponse.java
@@ -1,7 +1,6 @@
 package gov.nist.csd.pm.admintool.services;
 
-public class coordinatorResponse {
+public class CoordinatorScenarioResponse {
     public Boolean success;
     public String summary;
-    public String status;
 }

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorStatusResponse.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorStatusResponse.java
@@ -2,4 +2,10 @@ package gov.nist.csd.pm.admintool.services;
 
 public class CoordinatorStatusResponse {
     public String status;
+
+    public CoordinatorStatusResponse() {}
+
+    public CoordinatorStatusResponse(String status) {
+        this.status = status;
+    }
 }

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorStatusResponse.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/CoordinatorStatusResponse.java
@@ -1,0 +1,5 @@
+package gov.nist.csd.pm.admintool.services;
+
+public class CoordinatorStatusResponse {
+    public String status;
+}

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
@@ -27,6 +27,7 @@ public class RestService {
             try {
                 response = rt.getForEntity(url, coordinatorResponse.class, request);
             } catch (Exception e) {
+                noResponse.summary = e.getMessage();
                 noResponse.success = false;
                 return noResponse;
             }
@@ -34,6 +35,7 @@ public class RestService {
             try {
                 response = rt.postForEntity(url, request, coordinatorResponse.class);
             } catch (Exception e) {
+                noResponse.summary = e.getMessage();
                 noResponse.success = false;
                 return noResponse;
             }

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
@@ -3,10 +3,13 @@ package gov.nist.csd.pm.admintool.services;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
 import java.util.Map;
 
 @Service
@@ -22,6 +25,12 @@ public class RestService {
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, null);
         ResponseEntity<coordinatorResponse> response;
         coordinatorResponse noResponse = new coordinatorResponse();
+
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+
+        converter.setSupportedMediaTypes(Arrays.asList(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON));
+
+        rt.getMessageConverters().add(converter);
 
         if (method == HttpMethod.GET) {
             try {

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/RestService.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
@@ -25,23 +26,22 @@ public class RestService {
         RestTemplate rt = new RestTemplate();
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(params, null);
         ResponseEntity<CoordinatorScenarioResponse> response;
-        CoordinatorScenarioResponse noResponse = new CoordinatorScenarioResponse();
 
         if (method == HttpMethod.GET) {
             try {
                 response = rt.getForEntity(url, CoordinatorScenarioResponse.class, request);
-            } catch (Exception e) {
-                noResponse.summary = e.getMessage();
-                noResponse.success = false;
-                return noResponse;
+            } catch (RestClientException e) {
+                MainView.notify(e.getMessage(), MainView.NotificationType.ERROR);
+                e.printStackTrace();
+                return new CoordinatorScenarioResponse(false, e.getMessage());
             }
         } else /* if (method == HttpMethod.POST) */ {
             try {
                 response = rt.postForEntity(url, request, CoordinatorScenarioResponse.class);
-            } catch (Exception e) {
-                noResponse.summary = e.getMessage();
-                noResponse.success = false;
-                return noResponse;
+            } catch (RestClientException e) {
+                MainView.notify(e.getMessage(), MainView.NotificationType.ERROR);
+                e.printStackTrace();
+                return new CoordinatorScenarioResponse(false, e.getMessage());
             }
         }
 
@@ -61,8 +61,9 @@ public class RestService {
 
         try {
             response = rt.getForEntity(url, CoordinatorStatusResponse.class, request);
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             MainView.notify(e.getMessage(), MainView.NotificationType.ERROR);
+            e.printStackTrace();
             return false;
         }
 
@@ -70,7 +71,8 @@ public class RestService {
             MainView.notify("Coordinator status returned error", MainView.NotificationType.ERROR);
             return false;
         } else {
-            MainView.notify("Coordinator status returned " + response.getStatusCode(), MainView.NotificationType.SUCCESS);
+            MainView.notify("Coordinator status returned " + response.getStatusCode() + " with message: \"" +
+                    response.getBody().status + "\"", MainView.NotificationType.SUCCESS);
             return true;
         }
 

--- a/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/coordinatorResponse.java
+++ b/Dashboard/src/main/java/gov/nist/csd/pm/admintool/services/coordinatorResponse.java
@@ -3,4 +3,5 @@ package gov.nist.csd.pm.admintool.services;
 public class coordinatorResponse {
     public Boolean success;
     public String summary;
+    public String status;
 }


### PR DESCRIPTION
In response to #13, this branch adds the storedResponse field to the Action class. The Ping's run() method now has the side effect of storing the response from sendRequest() in this new storedResponse field. After the run() method is called, the explain() method can be called to produce a string explanation of the results.

Testing this branch can be done by running the dashboard and coordinator locally and running the ping test. An explanation should be visible by expanding any of the tests after running.

This implementation resembles the 2nd description under Goals of #13. It differs in a small way as it does not rename explain() to analyze() as per our discussion of #19.