### PR TITLE
Change dockerfile to use working version of Waverly Labs fwknop source

### DIFF
--- a/build/sdpclient_base_dockerfile
+++ b/build/sdpclient_base_dockerfile
@@ -9,6 +9,7 @@ RUN git clone https://github.com/WaverleyLabs/fwknop.git
 
 # install fwknop
 WORKDIR /fwknop
+RUN git checkout 3fe6965c00a3f478c8ca9c0be10e1dcb2bccb639
 RUN libtoolize --force && aclocal && autoheader && automake --force-missing --add-missing && autoconf
 RUN ./configure --disable-server --prefix=/usr
 RUN make && make install


### PR DESCRIPTION
I changed the dockerfile to use a specific version of the Waverly Labs source code that works with the e3labs environment.

Signed-off-by: Daniel Tingstrom <dtingstrom@mitre.org>